### PR TITLE
shorten menu to avoid overlapping header and footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,14 +45,14 @@
           <li><a href="{{ site.baseurl }}workbooks/2020_AK_Energy_Statistics.xlsx">Download 2020 Workbook</a></li>
           <li><a href="{{ site.baseurl }}workbooks/2021_AK_Energy_Statistics.xlsx">Download 2021 Workbook</a></li>
         </ul>
-        <h2>Summary Workbook Downloads:</h2>
+        <h2>Composite Workbook Downloads:</h2>
         <ul>
-          <li><a href="{{ site.baseurl }}workbooks/Energy_Stats_Financial_Tables.xlsx">Download Energy Statistics Financial Tables</a></li>
-          <li><a href="{{ site.baseurl }}workbooks/Energy_Stats_Generation_Tables.xlsx">Download Energy Statistics Generation Tables</a></li>
-          <li><a href="{{ site.baseurl }}workbooks/Energy_Stats_Infrastructure_2021.xlsx">Download Energy Statistics Infrastructure 2021</a></li>
-          <li><a href="{{ site.baseurl }}workbooks/Annual_Summary_Tables.xlsx">Download Annual Summary Tables</a></li>
-          <li><a href="{{ site.baseurl }}workbooks/intertie_lookup.xlsx">Download Alaska Intertie Look-up Table</a></li>
-          <li><a href="{{ site.baseurl }}workbooks/data_dictionary.xlsx">Download Data Dictionary</a></li>
+          <li><a href="{{ site.baseurl }}workbooks/Energy_Stats_Financial_Tables.xlsx">Financial Tables</a></li>
+          <li><a href="{{ site.baseurl }}workbooks/Energy_Stats_Generation_Tables.xlsx">Generation Tables</a></li>
+          <li><a href="{{ site.baseurl }}workbooks/Energy_Stats_Infrastructure_2021.xlsx">Infrastructure 2021</a></li>
+          <li><a href="{{ site.baseurl }}workbooks/Annual_Summary_Tables.xlsx">Annual Summary Tables</a></li>
+          <li><a href="{{ site.baseurl }}workbooks/intertie_lookup.xlsx">Alaska Intertie Look-up Table</a></li>
+          <li><a href="{{ site.baseurl }}workbooks/data_dictionary.xlsx">Data Dictionary</a></li>
         </ul>
       </header>
       <section>


### PR DESCRIPTION
Adding the extra menu items caused the header and the footer to overlap in the sidebar, disabling some of the links in the lower part of the menu.  I cannot change how the page was designed, so I (hopefully) made the menu shorter.